### PR TITLE
Fix #4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,5 @@ setup(
     entry_points={
         'console_scripts': ['states = us.cli.states:main']},
     platforms=['any'],
+    zip_safe=False,
 )


### PR DESCRIPTION
Explicitly specify zip_safe=False to avoid installing it as a packed egg.
