### PR TITLE
Add the travis build status to the readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. image:: https://travis-ci.org/unitedstates/python-us.svg?branch=master
+    :alt: Build Status
+    :target: http://travis-ci.org/unitedstates/python-us
+
 US: The Greatest Package in the World
 =====================================
 


### PR DESCRIPTION
This PR adds the travis ci heads up display to the README.