### PR TITLE
Always match exact names for `.lookup`

### DIFF
--- a/us/states.py
+++ b/us/states.py
@@ -120,6 +120,10 @@ def lookup(val, field=None, use_cache=True):
             val = val.upper()
             field = 'abbr'
         else:
+            # Always match correctly spelled names, without checking metaphone
+            exact_name_match = lookup(val.title(), field='name')
+            if exact_name_match is not None:
+                return exact_name_match
             val = jellyfish.metaphone(val)
             field = 'name_metaphone'
 


### PR DESCRIPTION
Issue #20 includes some examples of `us.states.lookup()` failing to return certain states and territories even when the provided value is the exact state name.  Some of the examples (definitely 'Wisconsin' and 'Washington', probably 'Utah') are caused by bugs in jellyfish, where it makes mistakes in constructing the metaphone. See https://github.com/jamesturk/jellyfish/issues/85.

This adds a failsafe for that situation whereby before making and comparing the metaphone for the provided value, it tries the lookup against the 'name' field (using `.title()` to make it case-insensitive).

This way regardless of any bugs or changes in jellyfish, the expected behavior of `us.states.lookup('Correct Full State Name')` won't fail.