### PR TITLE
Upgrade dependencies, especially tox to match CircleCI's version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ jellyfish==0.6.1
 # only required for tests
 pytest>=3.2,<3.3
 requests>=2.21,<2.22
-tox>=2.7,<2.8
+tox>=3.3,<3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jellyfish==0.6.1
 
 # only required for tests
-pytest>=3.2,<3.3
+pytest>=3.10,<3.11
 requests>=2.21,<2.22
 tox>=3.3,<3.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     zip_safe=False,
     classifiers=[
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
-envlist =
-    {py27,py37}
+envlist = py27,py37
 
 [testenv]
 deps = -rrequirements.txt
-setenv =
-    PYTHONPATH = .
 commands = pytest tests


### PR DESCRIPTION
This requires removing Python 3.3 support, which `tox` removed (because `setuptools` itself removed support).