### PR TITLE
us 3.0 release

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1
@@ -22,14 +22,14 @@ jobs:
     - name: Install dependencies
       run: |
         pipenv install --dev --python `which python`
-    # - name: Linting and formatting
-    #   run: |
-    #     # stop the build if there are Python syntax errors or undefined names
-    #     pipenv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-    #     pipenv run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    #     # check formatting
-    #     # pipenv run black --check us
+    - name: Linting and formatting
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        pipenv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        pipenv run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # check formatting
+        pipenv run black --check us
     - name: Test with pytest
       run: |
         pipenv run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 # Compilation and caching
 .cache/
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Compilation and caching
 .cache/
+.mypy_cache/
 .pytest_cache/
 .tox/
 __pycache__/

--- a/Pipfile
+++ b/Pipfile
@@ -4,13 +4,14 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pytest = "<3.3"
+black = "==19.10b0"
+flake8 = "*"
+pytest = "*"
 pytz = "*"
 requests = "<3.0"
-flake8 = "*"
 
 [packages]
-jellyfish = "==0.6.1"
+jellyfish = "==0.7.2"
 
 
 [pipenv]

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 black = "==19.10b0"
 flake8 = "*"
+importlib_metadata = {version = "*", markers = "python_version < '3.8'"}
 pytest = "*"
 pytz = "*"
 requests = "<3.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd634ff25b90366c98b1d37d474e02236bed71cda401826f7bad8d36fe7100fa"
+            "sha256": "400a91a015cad8ebd16bcd0cb1d181b71245de45fa6200322c64468409abc70c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,13 +16,35 @@
     "default": {
         "jellyfish": {
             "hashes": [
-                "sha256:5104e45a2b804b48a46a92a5e6d6e86830fe60ae83b1da32c867402c8f4c2094"
+                "sha256:cb09c50d7e2bb7b926fc7654762bc81f9c629e0c92ae7137bf22b34f39515286"
             ],
             "index": "pypi",
-            "version": "==0.6.1"
+            "version": "==0.7.2"
         }
     },
     "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+            ],
+            "index": "pypi",
+            "version": "==19.10b0"
+        },
         "certifi": {
             "hashes": [
                 "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
@@ -36,6 +58,13 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+            ],
+            "version": "==7.1.1"
         },
         "entrypoints": {
             "hashes": [
@@ -66,6 +95,34 @@
             ],
             "version": "==0.6.1"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+            ],
+            "version": "==8.2.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+            ],
+            "version": "==20.3"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
+                "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"
+            ],
+            "version": "==0.8.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
         "py": {
             "hashes": [
                 "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
@@ -87,13 +144,20 @@
             ],
             "version": "==2.1.1"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
+                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+            ],
+            "version": "==3.0.0a1"
+        },
         "pytest": {
             "hashes": [
-                "sha256:241d7e7798d79192a123ceaf64c602b4d233eacf6d6e42ae27caa97f498b7dc6",
-                "sha256:6d5bd4f7113b444c55a3bbb5c738a3dd80d43563d063fc42dcb0aaefbdd78b81"
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
             ],
             "index": "pypi",
-            "version": "==3.2.5"
+            "version": "==5.4.1"
         },
         "pytz": {
             "hashes": [
@@ -103,6 +167,32 @@
             "index": "pypi",
             "version": "==2019.3"
         },
+        "regex": {
+            "hashes": [
+                "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b",
+                "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8",
+                "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3",
+                "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e",
+                "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683",
+                "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1",
+                "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142",
+                "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3",
+                "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468",
+                "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e",
+                "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3",
+                "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a",
+                "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f",
+                "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6",
+                "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156",
+                "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b",
+                "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db",
+                "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd",
+                "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a",
+                "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948",
+                "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
+            ],
+            "version": "==2020.4.4"
+        },
         "requests": {
             "hashes": [
                 "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
@@ -111,12 +201,59 @@
             "index": "pypi",
             "version": "==2.23.0"
         },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
                 "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
             "version": "==1.25.9"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
+                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
+            ],
+            "version": "==0.1.9"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "400a91a015cad8ebd16bcd0cb1d181b71245de45fa6200322c64468409abc70c"
+            "sha256": "5a0a921119164483501c6eb69bf54d1ac7478c017126bf0b69f0ae12c0040eba"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -87,6 +87,15 @@
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
             "version": "==2.9"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
+                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+            ],
+            "index": "pypi",
+            "markers": "python_version < '3.8'",
+            "version": "==1.6.0"
         },
         "mccabe": {
             "hashes": [
@@ -254,6 +263,13 @@
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "version": "==3.1.0"
         }
     }
 }

--- a/README.rst
+++ b/README.rst
@@ -199,11 +199,19 @@ using: ::
 Changelog
 ---------
 
+3.0.0
+~~~~~
+
+* upgrade to jellyfish 0.7.2
+* drop support for Python 2.7
+
+
 2.0.1
 ~~~~~
 
 * fix Python 2.7 tests that ran with Python 3
 * revert to jellyfish 0.6.1 to support Python 2.7
+
 
 2.0.0
 ~~~~~

--- a/README.rst
+++ b/README.rst
@@ -144,11 +144,18 @@ method will generate a lookup between two specified fields.
     >>> us.states.mapping('abbr', 'name')
     {'AL': 'Alabama', 'AK': 'Alaska', 'AZ': 'Arizona', 'AR': 'Arkansas', ...
 
+This method uses `us.STATES_AND_TERRITORIES` as the default list of states
+it will create a mapping for, but this can be overridden by passing an
+additional states argument: ::
+
+    >>> us.states.mapping('fips', 'abbr', states=[us.states.DC])
+    {'11': 'DC'}
+
 
 DC should be granted statehood
 ------------------------------
 
-By default, Washington, DC does not appear in `us.STATES` or any of the
+Washington, DC does not appear in `us.STATES` or any of the
 related state lists, but is often treated as a state in practice and
 should be granted statehood anyway. DC can be automatically included in these
 lists by setting a `DC_STATEHOOD` environment variable to any truthy value
@@ -214,6 +221,7 @@ Changelog
 * add us.states.COMMONWEALTHS list of states that call themselves commonwealths 🎩
 * add DC to STATES, STATES_AND_TERRITORIES, STATES_CONTIGUOUS, or STATES_CONTINENTAL when DC_STATEHOOD environment variable is set
 * remove `region` parameter from `shapefile_urls()` method
+* `mapping()` no longer includes obsolete states
 * added type annotations
 
 

--- a/README.rst
+++ b/README.rst
@@ -196,18 +196,11 @@ When you need to know state information RIGHT AWAY, there's the *states* script.
 Running Tests
 -------------
 
-CircleCI is set up to automatically run unit tests against any new commits to
-the repo. To run these tests yourself in a standardized, Dockerized
-environment, install
-`the CircleCI CLI <https://circleci.com/docs/2.0/local-cli/>`_, and then
-execute the tests with: ::
+GitHub Actions are set up to automatically run unit tests against any new
+commits to the repo. To run these tests yourself: ::
 
-    circleci local execute --job build
-
-Alternatively, you can run tests against only your current version of Python,
-using: ::
-
-    pytest tests
+    pipenv install --dev
+    pipenv run pytest
 
 
 Changelog

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,20 @@ method will generate a lookup between two specified fields.
     {u'WA': u'Washington', u'VA': u'Virginia', u'DE': u'Delaware',...
 
 
+DC should be granted statehood
+------------------------------
+
+By default, Washington, DC does not appear in `us.STATES` or any of the
+related state lists, but is often treated as a state in practice and
+should be granted statehood anyway. DC can be automatically included in these
+lists by setting a `DC_STATEHOOD` environment variable to any truthy value
+before importing this package.
+
+::
+
+    DC_STATEHOOD=1
+
+
 CLI
 ----
 
@@ -204,6 +218,8 @@ Changelog
 
 * upgrade to jellyfish 0.7.2
 * drop support for Python 2.7
+* add us.states.COMMONWEALTHS list of states that call themselves commonwealths 🎩
+* add DC to STATES, STATES_AND_TERRITORIES, STATES_CONTIGUOUS, or STATES_CONTINENTAL when DC_STATEHOOD environment variable is set
 * added type annotations
 
 

--- a/README.rst
+++ b/README.rst
@@ -204,6 +204,7 @@ Changelog
 
 * upgrade to jellyfish 0.7.2
 * drop support for Python 2.7
+* added type annotations
 
 
 2.0.1

--- a/README.rst
+++ b/README.rst
@@ -36,16 +36,16 @@ Easy access to state information: ::
     >>> us.states.MD
     <State:Maryland>
     >>> us.states.MD.fips
-    u'24'
+    '24'
     >>> us.states.MD.name
-    u'Maryland'
+    'Maryland'
     >>> us.states.MD.is_contiguous
     True
 
 Includes territories too: ::
 
     >>> us.states.VI.name
-    u'Virgin Islands'
+    'Virgin Islands'
     >>> us.states.VI.is_territory
     True
     >>> us.states.MD.is_territory
@@ -54,22 +54,27 @@ Includes territories too: ::
 List of all (actual) states: ::
 
     >>> us.states.STATES
-    [<State:Alabama>, <State:Alaska>, <State:Arizona>, <State:Arkansas>,...
+    [<State:Alabama>, <State:Alaska>, <State:Arizona>, <State:Arkansas>, ...
     >>> us.states.TERRITORIES
-    [<State:American Samoa>, <State:Guam>, <State:Northern Mariana Islands>,...
+    [<State:American Samoa>, <State:Guam>, <State:Northern Mariana Islands>, ...
 
 And the whole shebang, if you want it: ::
 
     >>> us.states.STATES_AND_TERRITORIES
-    [<State:Alabama>, <State:Alaska>, <State:American Samoa>,...
+    [<State:Alabama>, <State:Alaska>, <State:American Samoa>, ...
 
 For convenience, `STATES`, `TERRITORIES`, and `STATES_AND_TERRITORIES` can be
 accessed directly from the `us` module: ::
 
     >>> us.states.STATES
-    [<State:Alabama>, <State:Alaska>, <State:Arizona>, <State:Arkansas>,...
+    [<State:Alabama>, <State:Alaska>, <State:Arizona>, <State:Arkansas>, ...
     >>> us.STATES
-    [<State:Alabama>, <State:Alaska>, <State:Arizona>, <State:Arkansas>,...
+    [<State:Alabama>, <State:Alaska>, <State:Arizona>, <State:Arkansas>, ...
+
+Some states like to be fancy and call themselves commonwealths: ::
+
+    >>> us.states.COMMONWEALTHS
+    [<State:Kentucky>, <State:Massachusetts>, <State:Pennsylvania>, <State:Virginia>]
 
 There's also a list of obsolete territories: ::
 
@@ -91,7 +96,7 @@ Get useful information: ::
 
     >>> state = us.states.lookup('maryland')
     >>> state.abbr
-    u'MD'
+    'MD'
 
 
 And for those days that you just can't remember how to spell Mississippi,
@@ -104,33 +109,26 @@ we've got phonetic name matching too: ::
 Shapefiles
 ----------
 
-You want shapefiles too? Gotcha covered.
+You want shapefiles too? As long as you want 2010 shapefiles, we've gotcha covered.
 
 ::
 
-    >>> shpurls = us.states.MD.shapefile_urls()
-    >>> for region, url in shpurls.items():
-    ...   print "%s: %s" % (region, url)
-    ...
-    county: http://www2.census.gov/geo/tiger/TIGER2010/COUNTY/2010/tl_2010_24_county10.zip
-    state: http://www2.census.gov/geo/tiger/TIGER2010/STATE/2010/tl_2010_24_state10.zip
-    cd: http://www2.census.gov/geo/tiger/TIGER2010/CD/111/tl_2010_24_cd111.zip
-    zcta: http://www2.census.gov/geo/tiger/TIGER2010/ZCTA5/2010/tl_2010_24_zcta510.zip
-    tract: http://www2.census.gov/geo/tiger/TIGER2010/TRACT/2010/tl_2010_24_tract10.zip
+    >>> urls = us.states.MD.shapefile_urls()
+    >>> sorted(urls.keys())
+    ['block', 'blockgroup', 'cd', 'county', 'state', 'tract', 'zcta']
+    >>> urls['block']
+    'https://www2.census.gov/geo/tiger/TIGER2010/TABBLOCK/2010/tl_2010_24_tabblock10.zip'
 
 The `shapefile_urls()` method on the State object generates shapefile URLs for
 the following regions:
 
-* state
+* block
+* blockgroup
+* census tract (tract)
+* congressional district (cd)
 * county
-* congressional district
+* state
 * zcta
-* census tract
-
-If you know what region you want, you can explicitly request it: ::
-
-    >>> us.states.MD.shapefile_urls('county')
-    u'http://www2.census.gov/geo/tiger/TIGER2010/COUNTY/2010/tl_2010_24_county10.zip'
 
 
 Mappings
@@ -142,9 +140,9 @@ method will generate a lookup between two specified fields.
 ::
 
     >>> us.states.mapping('fips', 'abbr')
-    {u'30': u'MT', u'54': u'WV', u'42': u'PA', u'48': u'TX', u'45': u'SC',...
+    {'01': 'AL', '02': 'AK', '04': 'AZ', '05': 'AR', '06': 'CA', ...
     >>> us.states.mapping('abbr', 'name')
-    {u'WA': u'Washington', u'VA': u'Virginia', u'DE': u'Delaware',...
+    {'AL': 'Alabama', 'AK': 'Alaska', 'AZ': 'Arizona', 'AR': 'Arkansas', ...
 
 
 DC should be granted statehood
@@ -178,19 +176,21 @@ When you need to know state information RIGHT AWAY, there's the *states* script.
         ap_abbr: Md.
         capital: Annapolis
         capital_tz: America/New_York
+        is_contiguous: True
+        is_continental: True
         is_obsolete: False
         name_metaphone: MRLNT
         statehood_year: 1788
         time_zones: America/New_York
 
       shapefiles:
-        blockgroup: http://www2.census.gov/geo/tiger/TIGER2010/BG/2010/tl_2010_24_bg10.zip
-        cd: http://www2.census.gov/geo/tiger/TIGER2010/CD/111/tl_2010_24_cd111.zip
-        county: http://www2.census.gov/geo/tiger/TIGER2010/COUNTY/2010/tl_2010_24_county10.zip
-        state: http://www2.census.gov/geo/tiger/TIGER2010/STATE/2010/tl_2010_24_state10.zip
-        tract: http://www2.census.gov/geo/tiger/TIGER2010/TRACT/2010/tl_2010_24_tract10.zip
-        zcta: http://www2.census.gov/geo/tiger/TIGER2010/ZCTA5/2010/tl_2010_24_zcta510.zip
-        block: http://www2.census.gov/geo/tiger/TIGER2010/TABBLOCK/2010/tl_2010_24_tabblock10.zip
+        tract: https://www2.census.gov/geo/tiger/TIGER2010/TRACT/2010/tl_2010_24_tract10.zip
+        cd: https://www2.census.gov/geo/tiger/TIGER2010/CD/111/tl_2010_24_cd111.zip
+        county: https://www2.census.gov/geo/tiger/TIGER2010/COUNTY/2010/tl_2010_24_county10.zip
+        state: https://www2.census.gov/geo/tiger/TIGER2010/STATE/2010/tl_2010_24_state10.zip
+        zcta: https://www2.census.gov/geo/tiger/TIGER2010/ZCTA5/2010/tl_2010_24_zcta510.zip
+        block: https://www2.census.gov/geo/tiger/TIGER2010/TABBLOCK/2010/tl_2010_24_tabblock10.zip
+        blockgroup: https://www2.census.gov/geo/tiger/TIGER2010/BG/2010/tl_2010_24_bg10.zip
 
 
 Running Tests
@@ -213,6 +213,7 @@ Changelog
 * drop support for Python 2.7
 * add us.states.COMMONWEALTHS list of states that call themselves commonwealths 🎩
 * add DC to STATES, STATES_AND_TERRITORIES, STATES_CONTIGUOUS, or STATES_CONTINENTAL when DC_STATEHOOD environment variable is set
+* remove `region` parameter from `shapefile_urls()` method
 * added type annotations
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open("README.rst").read()
 
 setup(
     name="us",
-    version="2.0.1",
+    version="3.0.0",
     author="Jeremy Carbaugh",
     author_email="jeremy@jcarbaugh.com",
     url="https://github.com/unitedstates/python-us",
@@ -13,11 +13,10 @@ setup(
     license="BSD",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["jellyfish==0.6.1"],
+    install_requires=["jellyfish==0.7.2"],
     entry_points={"console_scripts": ["states = us.cli.states:main"]},
     platforms=["any"],
     classifiers=[
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/us/__init__.py
+++ b/us/__init__.py
@@ -1,4 +1,4 @@
-from .states import (  # noqa
+from .states import (
     STATES,
     STATES_CONTIGUOUS,
     STATES_CONTINENTAL,

--- a/us/states.py
+++ b/us/states.py
@@ -97,13 +97,15 @@ def lookup(val, field: Optional[str] = None, use_cache: bool = True) -> Optional
             field = "name_metaphone"
 
     # see if result is in cache
-    cache_key = "%s:%s" % (field, val)
+    cache_key = f"{field}:{val}"
     if use_cache and cache_key in _lookup_cache:
         matched_state = _lookup_cache[cache_key]
 
     for state in itertools.chain(STATES_AND_TERRITORIES, OBSOLETE):
         if val == getattr(state, field):
-            _lookup_cache[cache_key] = matched_state = state
+            matched_state = state
+            if use_cache:
+                _lookup_cache[cache_key] = state
 
     return matched_state
 
@@ -112,7 +114,7 @@ def mapping(
     from_field: str, to_field: str, states: Optional[Iterable[State]] = None
 ) -> Dict[Any, Any]:
     if states is None:
-        states = itertools.chain(STATES_AND_TERRITORIES, OBSOLETE)
+        states = STATES_AND_TERRITORIES
     return {getattr(s, from_field): getattr(s, to_field) for s in states}
 
 

--- a/us/states.py
+++ b/us/states.py
@@ -2,6 +2,7 @@ import itertools
 import os
 import re
 from typing import Any, Dict, Iterable, List, Optional, Union
+from urllib.parse import urljoin
 
 import jellyfish  # type: ignore
 
@@ -49,27 +50,15 @@ class State:
         if not fips:
             return None
 
-        base_url = "https://www2.census.gov/geo/tiger/TIGER2010"
+        base = "https://www2.census.gov/geo/tiger/TIGER2010"
         urls = {
-            "tract": "{0}/TRACT/2010/tl_2010_{1}_tract10.zip".format(
-                base_url, self.fips
-            ),
-            "cd": "{0}/CD/111/tl_2010_{1}_cd111.zip".format(base_url, self.fips),
-            "county": "{0}/COUNTY/2010/tl_2010_{1}_county10.zip".format(
-                base_url, self.fips
-            ),
-            "state": "{0}/STATE/2010/tl_2010_{1}_state10.zip".format(
-                base_url, self.fips
-            ),
-            "zcta": "{0}/ZCTA5/2010/tl_2010_{1}_zcta510.zip".format(
-                base_url, self.fips
-            ),
-            "block": "{0}/TABBLOCK/2010/tl_2010_{1}_tabblock10.zip".format(
-                base_url, self.fips
-            ),
-            "blockgroup": "{0}/BG/2010/tl_2010_{1}_bg10.zip".format(
-                base_url, self.fips
-            ),
+            "tract": urljoin(base, f"TRACT/2010/tl_2010_{fips}_tract10.zip"),
+            "cd": urljoin(base, f"CD/111/tl_2010_{1}_cd111.zip"),
+            "county": urljoin(base, f"COUNTY/2010/tl_2010_{fips}_county10.zip"),
+            "state": urljoin(base, f"STATE/2010/tl_2010_{fips}_state10.zip"),
+            "zcta": urljoin(base, f"ZCTA5/2010/tl_2010_{fips}_zcta510.zip"),
+            "block": urljoin(base, f"TABBLOCK/2010/tl_2010_{fips}_tabblock10.zip"),
+            "blockgroup": urljoin(base, f"BG/2010/tl_2010_{fips}_bg10.zip"),
         }
 
         if region and region in urls:

--- a/us/states.py
+++ b/us/states.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import itertools
 import re
 

--- a/us/states.py
+++ b/us/states.py
@@ -1,10 +1,13 @@
 import itertools
+import os
 import re
 
 import jellyfish
 
 FIPS_RE = re.compile(r"^\d{2}$")
 ABBR_RE = re.compile(r"^[a-zA-Z]{2}$")
+
+DC_STATEHOOD = bool(os.environ.get("DC_STATEHOOD"))
 
 
 _lookup_cache = {}
@@ -1401,4 +1404,13 @@ STATES_CONTINENTAL = [
     WI,
     WY,
 ]
+
 STATES_AND_TERRITORIES = STATES + TERRITORIES
+
+COMMONWEALTHS = [KY, MA, PA, VA]
+
+if DC_STATEHOOD:
+    STATES.append(DC)
+    STATES_AND_TERRITORIES.append(DC)
+    STATES_CONTIGUOUS.append(DC)
+    STATES_CONTINENTAL.append(DC)

--- a/us/states.py
+++ b/us/states.py
@@ -41,28 +41,26 @@ class State:
     def __str__(self) -> str:
         return self.name
 
-    def shapefile_urls(
-        self, region: Optional[str] = None
-    ) -> Union[str, Dict[str, str], None]:
+    def shapefile_urls(self) -> Optional[Dict[str, str]]:
+        """ Shapefiles are available directly from the US Census Bureau:
+            https://www.census.gov/cgi-bin/geo/shapefiles/index.php
+        """
 
         fips = self.fips
 
         if not fips:
             return None
 
-        base = "https://www2.census.gov/geo/tiger/TIGER2010"
+        base = f"https://www2.census.gov/geo/tiger/TIGER2010/"
         urls = {
             "tract": urljoin(base, f"TRACT/2010/tl_2010_{fips}_tract10.zip"),
-            "cd": urljoin(base, f"CD/111/tl_2010_{1}_cd111.zip"),
+            "cd": urljoin(base, f"CD/111/tl_2010_{fips}_cd111.zip"),
             "county": urljoin(base, f"COUNTY/2010/tl_2010_{fips}_county10.zip"),
             "state": urljoin(base, f"STATE/2010/tl_2010_{fips}_state10.zip"),
             "zcta": urljoin(base, f"ZCTA5/2010/tl_2010_{fips}_zcta510.zip"),
             "block": urljoin(base, f"TABBLOCK/2010/tl_2010_{fips}_tabblock10.zip"),
             "blockgroup": urljoin(base, f"BG/2010/tl_2010_{fips}_bg10.zip"),
         }
-
-        if region and region in urls:
-            return urls[region]
 
         return urls
 

--- a/us/states.py
+++ b/us/states.py
@@ -1,8 +1,9 @@
 import itertools
 import os
 import re
+from typing import Any, Dict, Iterable, List, Optional, Union
 
-import jellyfish
+import jellyfish  # type: ignore
 
 FIPS_RE = re.compile(r"^\d{2}$")
 ABBR_RE = re.compile(r"^[a-zA-Z]{2}$")
@@ -10,24 +11,43 @@ ABBR_RE = re.compile(r"^[a-zA-Z]{2}$")
 DC_STATEHOOD = bool(os.environ.get("DC_STATEHOOD"))
 
 
-_lookup_cache = {}
+_lookup_cache: Dict[str, "State"] = {}
 
 
-class State(object):
+class State:
+
+    abbr: str
+    ap_abbr: Optional[str]
+    capital: Optional[str]
+    capital_tz: Optional[str]
+    fips: Optional[str]
+    is_territory: bool
+    is_obsolete: bool
+    is_contiguous: bool
+    is_continental: bool
+    name: str
+    name_metaphone: str
+    statehood_year: Optional[int]
+    time_zones: List[str]
+
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
-            self.__dict__[k] = v
+            setattr(self, k, v)
 
-    def __repr__(self):
-        return "<State:%s>" % self.name
+    def __repr__(self) -> str:
+        return f"<State:{self.name}>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def shapefile_urls(self, region=None):
+    def shapefile_urls(
+        self, region: Optional[str] = None
+    ) -> Union[str, Dict[str, str], None]:
 
-        if not self.fips:
-            return {}
+        fips = self.fips
+
+        if not fips:
+            return None
 
         base_url = "https://www2.census.gov/geo/tiger/TIGER2010"
         urls = {
@@ -58,7 +78,7 @@ class State(object):
         return urls
 
 
-def lookup(val, field=None, use_cache=True):
+def lookup(val, field: Optional[str] = None, use_cache: bool = True) -> Optional[State]:
     """ Semi-fuzzy state lookup. This method will make a best effort
         attempt at finding the state based on the lookup value provided.
 
@@ -77,6 +97,8 @@ def lookup(val, field=None, use_cache=True):
         with the `use_cache=False` argument.
     """
 
+    matched_state = None
+
     if field is None:
         if FIPS_RE.match(val):
             field = "fips"
@@ -90,18 +112,21 @@ def lookup(val, field=None, use_cache=True):
     # see if result is in cache
     cache_key = "%s:%s" % (field, val)
     if use_cache and cache_key in _lookup_cache:
-        return _lookup_cache[cache_key]
+        matched_state = _lookup_cache[cache_key]
 
     for state in itertools.chain(STATES_AND_TERRITORIES, OBSOLETE):
         if val == getattr(state, field):
-            _lookup_cache[cache_key] = state
-            return state
+            _lookup_cache[cache_key] = matched_state = state
+
+    return matched_state
 
 
-def mapping(from_field, to_field, states=None):
+def mapping(
+    from_field: str, to_field: str, states: Optional[Iterable[State]] = None
+) -> Dict[Any, Any]:
     if states is None:
         states = itertools.chain(STATES_AND_TERRITORIES, OBSOLETE)
-    return dict((getattr(s, from_field), getattr(s, to_field)) for s in states)
+    return {getattr(s, from_field): getattr(s, to_field) for s in states}
 
 
 AL = State(
@@ -1249,9 +1274,9 @@ WY = State(
 )
 
 
-OBSOLETE = [DK, OL, PI]
-TERRITORIES = [AS, GU, MP, PR, VI]
-STATES = [
+OBSOLETE: List[State] = [DK, OL, PI]
+TERRITORIES: List[State] = [AS, GU, MP, PR, VI]
+STATES: List[State] = [
     AL,
     AK,
     AZ,
@@ -1303,7 +1328,7 @@ STATES = [
     WI,
     WY,
 ]
-STATES_CONTIGUOUS = [
+STATES_CONTIGUOUS: List[State] = [
     AL,
     AZ,
     AR,
@@ -1353,7 +1378,7 @@ STATES_CONTIGUOUS = [
     WI,
     WY,
 ]
-STATES_CONTINENTAL = [
+STATES_CONTINENTAL: List[State] = [
     AL,
     AK,
     AZ,
@@ -1405,9 +1430,9 @@ STATES_CONTINENTAL = [
     WY,
 ]
 
-STATES_AND_TERRITORIES = STATES + TERRITORIES
+STATES_AND_TERRITORIES: List[State] = STATES + TERRITORIES
 
-COMMONWEALTHS = [KY, MA, PA, VA]
+COMMONWEALTHS: List[State] = [KY, MA, PA, VA]
 
 if DC_STATEHOOD:
     STATES.append(DC)

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from itertools import chain
 
 import jellyfish  # type: ignore
@@ -95,7 +94,14 @@ def test_mapping():
 def test_obsolete_mapping():
     mapping = us.states.mapping("abbr", "fips")
     for state in us.states.OBSOLETE:
-        assert state.abbr in mapping
+        assert state.abbr not in mapping
+
+
+def test_custom_mapping():
+    mapping = us.states.mapping("abbr", "fips", states=[us.states.DC, us.states.MD])
+    assert len(mapping) == 2
+    assert "DC" in mapping
+    assert "MD" in mapping
 
 
 # known bugs
@@ -119,7 +125,7 @@ def test_head():
     import requests
 
     for state in us.STATES_AND_TERRITORIES:
-        for region, url in state.shapefile_urls().items():
+        for url in state.shapefile_urls().values():
             resp = requests.head(url)
             assert resp.status_code == 200
 

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -147,3 +147,7 @@ def test_contiguous():
 def test_continental():
     # Lower 48 + DC + Alaska
     assert len(us.STATES_CONTINENTAL) == 49
+
+
+def test_dc():
+    assert us.states.DC not in us.STATES

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 from itertools import chain
 
-import jellyfish
-import pytest
+import jellyfish  # type: ignore
+import pytest  # type: ignore
 import pytz
 
 import us

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -140,12 +140,12 @@ def test_territories():
 
 
 def test_contiguous():
-    # Lower 48 + DC
+    # Lower 48
     assert len(us.STATES_CONTIGUOUS) == 48
 
 
 def test_continental():
-    # Lower 48 + DC + Alaska
+    # Lower 48 + Alaska
     assert len(us.STATES_CONTINENTAL) == 49
 
 


### PR DESCRIPTION
* upgrade to jellyfish 0.7.2
* drop support for Python 2.7
* add us.states.COMMONWEALTHS list of states that call themselves commonwealths 🎩
* add DC to STATES, STATES_AND_TERRITORIES, STATES_CONTIGUOUS, or STATES_CONTINENTAL when DC_STATEHOOD environment variable is set
* remove `region` parameter from `shapefile_urls()` method
* `mapping()` no longer includes obsolete states
* added type annotations