### PR TITLE
Fixes for python-us

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,7 +27,7 @@ jobs:
       if: ${{ matrix.python-version != '3.6' }}
     - name: Install dependencies
       run: |
-        pipenv install --dev --python `which python`
+        pipenv install --skip-lock --dev --python `which python`
     - name: Linting and formatting
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,4 +39,4 @@ jobs:
     - name: Test with pytest
       run: |
         pipenv run pytest us/tests --timezone
-        DC_STATEHOOD=yes pipenv run us/tests --dc-statehood 
+        DC_STATEHOOD=yes pipenv run pytest us/tests --dc-statehood 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install pipenv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,8 +17,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install pipenv
+    - name: Install pipenv for python 3.6
       uses: dschep/install-pipenv-action@v1
+      if: ${{ matrix.python-version == '3.6' }}
+      with:
+        version: 2022.4.20
+    - name: Install pipenv for modern python
+      uses: dschep/install-pipenv-action@v1
+      if: ${{ matrix.python-version != '3.6' }}
     - name: Install dependencies
       run: |
         pipenv install --dev --python `which python`

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,4 +32,4 @@ jobs:
         pipenv run black --check us
     - name: Test with pytest
       run: |
-        pipenv run pytest
+        pipenv run pytest --timezone

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,4 +32,5 @@ jobs:
         pipenv run black --check us
     - name: Test with pytest
       run: |
-        pipenv run pytest --timezone
+        pipenv run pytest us/tests --timezone
+        DC_STATEHOOD=yes pipenv run us/tests --dc-statehood 

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ verify_ssl = true
 [dev-packages]
 black = "22.8.0"
 flake8 = "*"
-importlib_metadata = {version = "*", markers = "python_version < '3.8'"}
 pytest = "*"
 pytz = "*"
 requests = "<3.0"

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,9 @@ importlib_metadata = {version = "*", markers = "python_version < '3.8'"}
 pytest = "*"
 pytz = "*"
 requests = "<3.0"
+geopandas = "*"
+rtree = "*"
+iso6709 = "*"
 
 [packages]
 jellyfish = "<1.0"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-black = "==19.10b0"
+black = "22.8.0"
 flake8 = "*"
 importlib_metadata = {version = "*", markers = "python_version < '3.8'"}
 pytest = "*"
@@ -12,7 +12,7 @@ pytz = "*"
 requests = "<3.0"
 
 [packages]
-jellyfish = "==0.7.2"
+jellyfish = "<1.0"
 
 
 [pipenv]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "464223c6398ee2b309f5b189779c1fa62bdde7da4b0bf7584ccfcf38e27ba4ec"
+            "sha256": "ac568394082a04137fc33977aedeeeb2a40c557c760b9d4dc6c1909e3d226ca3"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -96,6 +96,40 @@
             "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
         },
+        "click-plugins": {
+            "hashes": [
+                "sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b",
+                "sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8"
+            ],
+            "version": "==1.1.1"
+        },
+        "cligj": {
+            "hashes": [
+                "sha256:a4bc13d623356b373c2c27c53dbd9c68cae5d526270bfa71f6c6fa69669c6b27",
+                "sha256:c1ca117dbce1fe20a5809dc96f01e1c2840f6dcc939b3ddbb1111bf330ba82df"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
+            "version": "==0.7.2"
+        },
+        "fiona": {
+            "hashes": [
+                "sha256:01d3d95d945b9f1b69ed67db79802da89c974a38c3469cdda8bbf0e59e6a8f68",
+                "sha256:0e873ebd554219318eab2f5853b9887a7ffb0ee4e721674c241797090f26ee97",
+                "sha256:31192e2c31491a1005d6785c9963533c453151ec71c403157c962f53eef8922f",
+                "sha256:50ec5fb9430713489a6b7e2ad0b7d47f2d74c9f20632f0a3566c13cba18c0943",
+                "sha256:63435dab1ae7074a582178f4118c908aa53493e1f0d30b96da0c41930ae8a40a",
+                "sha256:acc15fd01c161d6fa4ffe44c0f92f793fe2b449c8d8d0748630ba7ad3770bec4",
+                "sha256:b2fe3d2d40c6aa804d9140cc12269ce8763bbff889172ed5795906818cdd5084",
+                "sha256:bef8be24b855681cfd4ad160f8f526b646d5ba46bbce6c18d8bd6770a1d0ecf0",
+                "sha256:c586cd6b32b5cfbe2d72e223e496c1741d3b70daf481f2d15bfdee47073392c4",
+                "sha256:d1d8a0124ad4fdf101ee8a1369c5d97114433eb9cc31794eaccab5124dc4edcb",
+                "sha256:d766b44d3cf1edaa94e4606292cf9e2c704a91ce4c793fba7ae63f2accd0dcbc",
+                "sha256:db45b13cecf9b1915e8257a163214040059e832b87c531a2f339129f8fabf7e1",
+                "sha256:dbfcfe31e5d0b40cfd8221bf6d5f95483c8c5e93108285d43bb101ea8012fe2b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.9a2"
+        },
         "flake8": {
             "hashes": [
                 "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db",
@@ -103,6 +137,14 @@
             ],
             "index": "pypi",
             "version": "==5.0.4"
+        },
+        "geopandas": {
+            "hashes": [
+                "sha256:f0f0c8d0423d30cf81de2056d853145c4362739350a7f8f2d72cc7409ef1eca1",
+                "sha256:f3344937f3866e52996c7e505d56dae78be117dc840cd1c23507da0b33c0af71"
+            ],
+            "index": "pypi",
+            "version": "==0.11.1"
         },
         "idna": {
             "hashes": [
@@ -127,6 +169,14 @@
             ],
             "version": "==1.1.1"
         },
+        "iso6709": {
+            "hashes": [
+                "sha256:ae482a0ad700ae1496eb9f86b4e23b203b9b947513877938bbe26581c6864aa3",
+                "sha256:f05621ad20571ffc9d47c3498c8dceb3473ab1fb540192ecd282b9ec760e66af"
+            ],
+            "index": "pypi",
+            "version": "==0.1.5"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
@@ -135,12 +185,53 @@
             "markers": "python_version >= '3.6'",
             "version": "==0.7.0"
         },
+        "munch": {
+            "hashes": [
+                "sha256:8fdb6c5cb8ea62611424ed71b4aa896851c6c53952872cbb7d6767dc34119e89",
+                "sha256:b15f80b3ca99b9af0048215f9c81e718fdc6b2accecbcff573d12cddc90fd8c3"
+            ],
+            "version": "==2.5.1.dev12"
+        },
         "mypy-extensions": {
             "hashes": [
                 "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
                 "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
             ],
             "version": "==0.4.3"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:004f0efcb2fe1c0bd6ae1fcfc69cc8b6bf2407e0f18be308612007a0762b4089",
+                "sha256:09f6b7bdffe57fc61d869a22f506049825d707b288039d30f26a0d0d8ea05164",
+                "sha256:0ea3f98a0ffce3f8f57675eb9119f3f4edb81888b6874bc1953f91e0b1d4f440",
+                "sha256:17c0e467ade9bda685d5ac7f5fa729d8d3e76b23195471adae2d6a6941bd2c18",
+                "sha256:1f27b5322ac4067e67c8f9378b41c746d8feac8bdd0e0ffede5324667b8a075c",
+                "sha256:22d43376ee0acd547f3149b9ec12eec2f0ca4a6ab2f61753c5b29bb3e795ac4d",
+                "sha256:2ad3ec9a748a8943e6eb4358201f7e1c12ede35f510b1a2221b70af4bb64295c",
+                "sha256:301c00cf5e60e08e04d842fc47df641d4a181e651c7135c50dc2762ffe293dbd",
+                "sha256:39a664e3d26ea854211867d20ebcc8023257c1800ae89773cbba9f9e97bae036",
+                "sha256:51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd",
+                "sha256:78a63d2df1d947bd9d1b11d35564c2f9e4b57898aae4626638056ec1a231c40c",
+                "sha256:7cd1328e5bdf0dee621912f5833648e2daca72e3839ec1d6695e91089625f0b4",
+                "sha256:8355fc10fd33a5a70981a5b8a0de51d10af3688d7a9e4a34fcc8fa0d7467bb7f",
+                "sha256:8c79d7cf86d049d0c5089231a5bcd31edb03555bd93d81a16870aa98c6cfb79d",
+                "sha256:91b8d6768a75247026e951dce3b2aac79dc7e78622fc148329135ba189813584",
+                "sha256:94c15ca4e52671a59219146ff584488907b1f9b3fc232622b47e2cf832e94fb8",
+                "sha256:98dcbc02e39b1658dc4b4508442a560fe3ca5ca0d989f0df062534e5ca3a5c1a",
+                "sha256:a64403f634e5ffdcd85e0b12c08f04b3080d3e840aef118721021f9b48fc1460",
+                "sha256:bc6e8da415f359b578b00bcfb1d08411c96e9a97f9e6c7adada554a0812a6cc6",
+                "sha256:bdc9febce3e68b697d931941b263c59e0c74e8f18861f4064c1f712562903411",
+                "sha256:c1ba66c48b19cc9c2975c0d354f24058888cdc674bebadceb3cdc9ec403fb5d1",
+                "sha256:c9f707b5bb73bf277d812ded9896f9512a43edff72712f31667d0a8c2f8e71ee",
+                "sha256:d5422d6a1ea9b15577a9432e26608c73a78faf0b9039437b075cf322c92e98e7",
+                "sha256:e5d5420053bbb3dd64c30e58f9363d7a9c27444c3648e61460c1237f9ec3fa14",
+                "sha256:e868b0389c5ccfc092031a861d4e158ea164d8b7fdbb10e3b5689b4fc6498df6",
+                "sha256:efd9d3abe5774404becdb0748178b48a218f1d8c44e0375475732211ea47c67e",
+                "sha256:f8c02ec3c4c4fcb718fdf89a6c6f709b14949408e8cf2a2be5bfa9c49548fd85",
+                "sha256:ffcf105ecdd9396e05a8e58e81faaaf34d3f9875f137c7372450baa5d77c9a54"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==1.23.3"
         },
         "packaging": {
             "hashes": [
@@ -149,6 +240,33 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==21.3"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:0329e22df7e85fd4cd4df5d186fad200fa879abc62583a2b0fa5919032b3e7d5",
+                "sha256:0a3cfd8777f3eb9fa6df12ea6f4aea338a9205507eb12d8dca3b3f00cf4ffe17",
+                "sha256:1002500cd99fbd00b4421f252ee7f8be5b6aabfeff29d5a744ec73ba3a917beb",
+                "sha256:1db16e716aac37e0d77278526c59027bdd02701994586912d83f4bf10ef80a06",
+                "sha256:1e2b9186b4d960043c47f62aeb489d88f74bfa574b486d4d2fd52bf496f94c23",
+                "sha256:4517b8f426b152620143ada0059e3a4142802f9582372885eb56a509283ca216",
+                "sha256:53400419ae6d9cec1cc8df719c0cbf7f76da9afd1725a1428993b112adb7f268",
+                "sha256:61fbe9e0e638a606ad47e362af5d8c71e9d33e4e5824e5b8d3811cdb45aabc89",
+                "sha256:6b842469bbdf1e7733c70b4e9bceee90ff8f421ad871cefb09d7e4d326557112",
+                "sha256:774c07952f1da5c8813ca082744161797dfd05c9bd16f0afae8c9774e82e06e6",
+                "sha256:7c0bd042e4d43c185f21a5616b98eaa0f5370ac816e633949a2c3ce922d35c0f",
+                "sha256:a9a8b27f08c7fe9b9bdb8631e663af140cee0deeac102dee84c867633b460e2a",
+                "sha256:b0cb459061105bc0927ebba493cb4cb745e43a18532b92e49000c4f34ea30eb9",
+                "sha256:bc626256a6d430e96b6e47208c0e5f9ad0403558a2237873e68ec37ce321bf70",
+                "sha256:bf99d2ba08dd476c3adf2baaa6e6ed16f78a35832146555260c08915e0633e3f",
+                "sha256:c0df2515125d83489521e1edfebe7cab2276c9b2984a21dcc5e8ef563e4b8e0d",
+                "sha256:c8867fc7722fc5f10c61ee7e8b76295c41d20d0f26b1f7341837476efca66601",
+                "sha256:cba004d0d33a28722c89b41512d90398f8041d0c24492f794863db1ddcc7932f",
+                "sha256:dac53ad9e6c45e1dae2263a6789aab79aa3b24b8974760ce22febe05b0b63865",
+                "sha256:f972af3232d41f6c755682f3f11ba0e5f0cf546a7eb6b3beba36677c5fcb2ca0",
+                "sha256:f9f763d6a88c21690a5cad79c6f3074c3b71e04f8d949edf1970d27f0d746cf5"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0rc0"
         },
         "pathspec": {
             "hashes": [
@@ -206,6 +324,39 @@
             "markers": "python_full_version >= '3.6.8'",
             "version": "==3.0.9"
         },
+        "pyproj": {
+            "hashes": [
+                "sha256:12f62c20656ac9b6076ebb213e9a635d52f4f01fef95310121d337e62e910cb6",
+                "sha256:14ad113b5753c6057f9b2f3c85a6497cef7fa237c4328f2943c0223e98c1dde6",
+                "sha256:1f9c100fd0fd80edbc7e4daa303600a8cbef6f0de43d005617acb38276b88dc0",
+                "sha256:221d8939685e0c43ee594c9f04b6a73a10e8e1cc0e85f28be0b4eb2f1bc8777d",
+                "sha256:25a36e297f3e0524694d40259e3e895edc1a47492a0e30608268ffc1328e3f5d",
+                "sha256:2cb8592259ea54e7557523b079d3f2304081680bdb48bfbf0fd879ee6156129c",
+                "sha256:3b85acf09e5a9e35cd9ee72989793adb7089b4e611be02a43d3d0bda50ad116b",
+                "sha256:45554f47d1a12a84b0620e4abc08a2a1b5d9f273a4759eaef75e74788ec7162a",
+                "sha256:4688b4cd62cbd86b5e855f9e27d90fbb53f2b4c2ea1cd394a46919e1a4151b89",
+                "sha256:47ad53452ae1dc8b0bf1df920a210bb5616989085aa646592f8681f1d741a754",
+                "sha256:48787962232109bad8b72e27949037a9b03591228a6955f25dbe451233e8648a",
+                "sha256:4a23d84c5ffc383c7d9f0bde3a06fc1f6697b1b96725597f8f01e7b4bef0a2b5",
+                "sha256:4e161114bc92701647a83c4bbce79489984f12d980cabb365516e953d1450885",
+                "sha256:4fd425ee8b6781c249c7adb7daa2e6c41ce573afabe4f380f5eecd913b56a3be",
+                "sha256:52e54796e2d9554a5eb8f11df4748af1fbbc47f76aa234d6faf09216a84554c5",
+                "sha256:65a0bcdbad95b3c00b419e5d75b1f7e450ec17349b5ea16bf7438ac1d50a12a2",
+                "sha256:77d5f519f3cdb94b026ecca626f78db4f041afe201cf082079c8c0092a30b087",
+                "sha256:82200b4569d68b421c079d2973475b58d5959306fe758b43366e79fe96facfe5",
+                "sha256:954b068136518b3174d0a99448056e97af62b63392a95c420894f7de2229dae6",
+                "sha256:9a496d9057b2128db9d733e66b206f2d5954bbae6b800d412f562d780561478c",
+                "sha256:a454a7c4423faa2a14e939d08ef293ee347fa529c9df79022b0585a6e1d8310c",
+                "sha256:a708445927ace9857f52c3ba67d2915da7b41a8fdcd9b8f99a4c9ed60a75eb33",
+                "sha256:ccb4b70ad25218027f77e0c8934d10f9b7cdf91d5e64080147743d58fddbc3c0",
+                "sha256:d94afed99f31673d3d19fe750283621e193e2a53ca9e0443bf9d092c3905833b",
+                "sha256:e7e609903572a56cca758bbaee5c1663c3e829ddce5eec4f368e68277e37022b",
+                "sha256:f343725566267a296b09ee7e591894f1fdc90f84f8ad5ec476aeb53bd4479c07",
+                "sha256:f80adda8c54b84271a93829477a01aa57bc178c834362e9f74e1de1b5033c74c"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.4.0"
+        },
         "pytest": {
             "hashes": [
                 "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
@@ -213,6 +364,14 @@
             ],
             "index": "pypi",
             "version": "==7.1.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
         },
         "pytz": {
             "hashes": [
@@ -230,12 +389,104 @@
             "index": "pypi",
             "version": "==2.28.1"
         },
+        "rtree": {
+            "hashes": [
+                "sha256:0475b2e7fe813c427ceb21e57c22f8b4b7fee6e5966db8a200688163d4853f14",
+                "sha256:062439d3a33d95281445960af76b6189b987cda0803fdc1818e31b68bce989d1",
+                "sha256:0ab0dccff665389329f8d2e623131a1af3ab82b6de570f8c494a429c129f3e65",
+                "sha256:0ffaa03d1f7e8291de7cd8a11f92e10579f145dc3a08cd46a9eea65cc7b42173",
+                "sha256:171aa361b3542bf1e47bdee54c611644bb33d35502e2ceea57ac89cf35330554",
+                "sha256:24185f39b277aaca0566284858de02edc80dc7b120233be38fcf3b4c7d2e72dc",
+                "sha256:264e3b255a1fc6aaa2ddbcedfc15ac40578433f6b35a0c7aaba026215d91d8c3",
+                "sha256:26b2275ebc738cb6a0473c15d80fdfe820ef319015009f8f0789e586552cf411",
+                "sha256:29a1a4452e334eaf3299c8b95f137a2ccafbccfd856041f612ec933eeafb2cf5",
+                "sha256:3e28303d84f8b5509e26db7c2aa533692a6112a430cc955a7a7e6d899c9d5996",
+                "sha256:44df5adc12841b94adcbc4e5aaada248e98a4dc2017c8c7060f9a782ef63e050",
+                "sha256:4f2f93c997de551a1a0fa4065e713270ad9a509aeeb143c5b46f332c0759f314",
+                "sha256:55b771e62b1e391a44776ef9f906944796213cc3cb48ffd6b22493684c68a859",
+                "sha256:728cf9b774ed6f120f2ed072082431c14af8243d477656b5b7dc1ff855fe7786",
+                "sha256:757bbf9ca38c241e34812a646f16ffda2cabd535bcd815041b83fe091df7a85c",
+                "sha256:7f2c0bd3e7d4b68cc27ab605b18487440427d5febba5f4b747b694f9de601c6f",
+                "sha256:825c1f74a84e9857657c04503c4c50b9f170114183fa2db9211a5d8650cf1ffa",
+                "sha256:8d18efe4e69f6b7daee9aaced21e0218786209d55235c909c78dbc5c12368790",
+                "sha256:973ce22ee8bafa44b3df24c6bf78012e534e1f36103e0bbfbb193ec48e9be22a",
+                "sha256:a48f46dbb6ab0cb135a43d90529e1fa09a6dd80149a34844f2adf8414b4ab71a",
+                "sha256:a91d7b514210ae93029c2a7ed83b2595ca73de5e08a9d87fcdf3a784a7b3ef54",
+                "sha256:b0256ed9c27037892bcb7167e7f5c469ee7c5de38c5a895145e33c320584babe",
+                "sha256:b2110fb8675bf809bba431a1876ba76ca5dde829a4de40aa7851941452a01278",
+                "sha256:bc18d4df3edb3b889b177ba39238770afdb5787fb803677c3aadea42a6931485",
+                "sha256:bc6e7384684a260eb2f04fcac64ca5ffe28876132a11d1a883db2a5db8becb64",
+                "sha256:c2b14f7603576b73a5e0fd2e35394db08c5ca3cfa41e4c8530128d91e5e43dd3",
+                "sha256:d0483482121346b093b9a42518d40f921adf445915b7aea307eb26768c839682",
+                "sha256:e436d8da7527655fd0512dd6a5218f604a3806849f3981ec0ca64930dc19b7f2",
+                "sha256:efdaf7137303af7a85ddd224bacdb27f9f7ece99e0dec627c900e12f22cdefd0",
+                "sha256:fe3954a51d691d3938cbac42ac97f4acacbea8ea622a375df901318a5c4ab0e9"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82",
+                "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==65.3.0"
+        },
+        "shapely": {
+            "hashes": [
+                "sha256:007f0d51d045307dc3addd1c318d18f450c565c8ea96ea41304e020ca34d85b7",
+                "sha256:033b9eaf50c9de4c87b0d1ffa532edcf7420b70a329c630431da50071be939d9",
+                "sha256:04f416aa8ca9480b5cd74d2184fe43d4196a5941046661f7be27fe5c10f89ede",
+                "sha256:1d431ac2bb75e7c59a75820719b2f0f494720d821cb68eeb2487812d1d7bc287",
+                "sha256:1f071175777f87d9220c24e4576dcf972b14f93dffd05a1d72ee0555dfa2a799",
+                "sha256:20157b20f32eac57a56b5ef5a5a0ffb5288e1554e0172bc9452d3de190965709",
+                "sha256:20c40085835fbd5b12566b9b0a6d718b0b6a4d308ff1fff5b19d7cf29f75cc77",
+                "sha256:2a6e2fb40415cecf67dff1a13844d27a11c09604839b5cfbbb41b80cf97a625c",
+                "sha256:34765b0495c6297adb95d7de8fc62790f8eaf8e7fb96260dd644cf11d37b3d21",
+                "sha256:41e1395bb3865e42ca3dec857669ed3ab90806925fce38c47d7f92bd4276f7cd",
+                "sha256:471ce47f3b221731b3a8fb90c24dd5899140ca892bb78c5df49b340a73da5bd2",
+                "sha256:4c10d55a2dfab648d9aeca1818f986e505f29be2763edd0910b50c76d73db085",
+                "sha256:4f14ea7f041412ff5b277d5424e76638921ba771c43b21b20706abc7900d5ce9",
+                "sha256:53d453f40e5b1265b8806ac7e5f3ce775b758e5c42c24239e3d8de6e861b7699",
+                "sha256:5b77a7fd5bbf051a640d25db85fc062d245ef03cd80081321b6b87213a8b0892",
+                "sha256:5d629bcf68b45dfdfd85cc0dc37f5325d4ce9341b235f16969c1a76599476e84",
+                "sha256:5f3bf1d985dc8367f480f68f07770f57a5fe54477e98237c6f328db79568f1e2",
+                "sha256:6702a5df484ca92bbd1494b5945dd7d6b8f6caab13ca9f6240e64034a114fa13",
+                "sha256:687520cf1db1fac2970cca5eb2ea037c1862b2e6938a514f9f6106c9d4ac0445",
+                "sha256:6c399712b98fef80ef53748a572b229788650b0af535e6d4c5a3168aabbc0013",
+                "sha256:7855ac13c5a951bcef1f3834d1affeeacea42a4abd2c0f46b341229b350f2406",
+                "sha256:79da29fde8ad2ca791b324f2cc3e75093573f69488ade7b524f79d781b042699",
+                "sha256:95a864b83857de736499d171785b8e71df97e8cef62d4e36b34f057b5a4dc98c",
+                "sha256:a195e51caafa218291f2cbaa3fef69fd3353c93ec4b65b2a4722c4cf40c3198c",
+                "sha256:a2cc137d525a2e54557df2f70f7b9d52749840e1d877cf500a8f7f0f77170552",
+                "sha256:a352f00637dda1354c549b602d9dcc69a7048d5d64dcdaf3b5e702d0bf5faad2",
+                "sha256:b1756c28a48a61e5581720171a89d69ae303d5faffc58efef0dab498e16a50f1",
+                "sha256:b70463ef505f509809b92ffb1202890a1236ce9f21666020de289fed911fdeaf",
+                "sha256:bb371511269d8320652b980edb044f9c45c87df12ecce00c4bb1d0662d53bdb4",
+                "sha256:be731cf35cfd54091d62cd63a4c4d87a97db68c2224408ec6ef28c6333d74501",
+                "sha256:d7a6fd1329f75e290b858e9faeef15ae76d7ea05a02648fe216fec3c3bed4eb0",
+                "sha256:e018163500109ab4c9ad51d018ba28abb1aed5b0451476859e189fbb00c46c7b",
+                "sha256:eac2d08c0a02dccffd7f836901ea1d1b0f8e7ff3878b2c7a45443f0a34e7f087",
+                "sha256:f6801a33897fb54ce39d5e841214192ecf95f4ddf8458d17e196a314fefe43bb"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.8.4"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
         },
         "typing-extensions": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ac568394082a04137fc33977aedeeeb2a40c557c760b9d4dc6c1909e3d226ca3"
+            "sha256": "0e72408894b482fbc73b7a2422c6199911d33cb07e3cf308f7c9276b7fe4c246"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -153,14 +153,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==4.12.0"
         },
         "iniconfig": {
             "hashes": [
@@ -486,7 +478,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_full_version < '3.11.0a7'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
         "typing-extensions": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5a0a921119164483501c6eb69bf54d1ac7478c017126bf0b69f0ae12c0040eba"
+            "sha256": "464223c6398ee2b309f5b189779c1fa62bdde7da4b0bf7584ccfcf38e27ba4ec"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,260 +16,243 @@
     "default": {
         "jellyfish": {
             "hashes": [
-                "sha256:cb09c50d7e2bb7b926fc7654762bc81f9c629e0c92ae7137bf22b34f39515286"
+                "sha256:35eefbbfb93aa82a4a4e5eafc3b866c3ac26418f064c4538c345b11cdebf2b5b",
+                "sha256:3b6ffe2ab3d557892db1f87bb4846dfb7a697eba9248d6f2554555f998f4a265",
+                "sha256:40c9a2ffd8bd3016f7611d424120442f627f56d518a106847dc93f0ead6ad79a",
+                "sha256:465a2109e16b87554aec7ddd4ba0c8798f2377f6f957aed30dc64ab46b47e703",
+                "sha256:514c9d9e69170ac2c3eff48ba02d4f03540538d63028b76ebc8a2cb589e8cdd0",
+                "sha256:8759c6d34f1bea5860ab5807968399b9dd259c703f6c5071fcd5703bf7a00d99",
+                "sha256:954290c165511681aa9627e3c4305acf425942ad64e745ea56865cff8e0661a6",
+                "sha256:96290b1e1acb30b2466112ba4ed9c7b511ac7028d7e9096b38558ea1f0484a98",
+                "sha256:a3b9fae0cba82ef5839d8f2e2275387807ccb6c3041fdc8e89bbcadaf09a5837",
+                "sha256:b682a6235d581669e6a9f0a6d716a6606bf42525ab90de4c6a49c36bfbdd73b4",
+                "sha256:c0cbe9d294f75b4fa05c0a5cb7ca4c8e85297a3ec9bf66d13ed330190a86381f",
+                "sha256:c891c1465679bc9c2d114f75364e3b4dadeb6959a37c3e3fa41bc7746a84e060",
+                "sha256:cc68f01450290d5ad631f63917834788c178eebaa6efb8196319eea2f146ed70"
             ],
             "index": "pypi",
-            "version": "==0.7.2"
+            "version": "==0.9.0"
         }
     },
     "develop": {
-        "appdirs": {
-            "hashes": [
-                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
-                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
-            ],
-            "version": "==1.4.3"
-        },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
         },
         "black": {
             "hashes": [
-                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
-                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+                "sha256:0a12e4e1353819af41df998b02c6742643cfef58282915f781d0e4dd7a200411",
+                "sha256:0ad827325a3a634bae88ae7747db1a395d5ee02cf05d9aa7a9bd77dfb10e940c",
+                "sha256:32a4b17f644fc288c6ee2bafdf5e3b045f4eff84693ac069d87b1a347d861497",
+                "sha256:3b2c25f8dea5e8444bdc6788a2f543e1fb01494e144480bc17f806178378005e",
+                "sha256:4a098a69a02596e1f2a58a2a1c8d5a05d5a74461af552b371e82f9fa4ada8342",
+                "sha256:5107ea36b2b61917956d018bd25129baf9ad1125e39324a9b18248d362156a27",
+                "sha256:53198e28a1fb865e9fe97f88220da2e44df6da82b18833b588b1883b16bb5d41",
+                "sha256:5594efbdc35426e35a7defa1ea1a1cb97c7dbd34c0e49af7fb593a36bd45edab",
+                "sha256:5b879eb439094751185d1cfdca43023bc6786bd3c60372462b6f051efa6281a5",
+                "sha256:78dd85caaab7c3153054756b9fe8c611efa63d9e7aecfa33e533060cb14b6d16",
+                "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e",
+                "sha256:8ce13ffed7e66dda0da3e0b2eb1bdfc83f5812f66e09aca2b0978593ed636b6c",
+                "sha256:a05da0430bd5ced89176db098567973be52ce175a55677436a271102d7eaa3fe",
+                "sha256:a983526af1bea1e4cf6768e649990f28ee4f4137266921c2c3cee8116ae42ec3",
+                "sha256:bc4d4123830a2d190e9cc42a2e43570f82ace35c3aeb26a512a2102bce5af7ec",
+                "sha256:c3a73f66b6d5ba7288cd5d6dad9b4c9b43f4e8a4b789a94bf5abfb878c663eb3",
+                "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd",
+                "sha256:cea1b2542d4e2c02c332e83150e41e3ca80dc0fb8de20df3c5e98e242156222c",
+                "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4",
+                "sha256:d839150f61d09e7217f52917259831fe2b689f5c8e5e32611736351b89bb2a90",
+                "sha256:dd82842bb272297503cbec1a2600b6bfb338dae017186f8f215c8958f8acf869",
+                "sha256:e8166b7bfe5dcb56d325385bd1d1e0f635f24aae14b3ae437102dedc0c186747",
+                "sha256:e981e20ec152dfb3e77418fb616077937378b322d7b26aa1ff87717fb18b4875"
             ],
             "index": "pypi",
-            "version": "==19.10b0"
+            "version": "==22.8.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5",
+                "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"
             ],
-            "version": "==2020.4.5.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.9.14"
         },
-        "chardet": {
+        "charset-normalizer": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.1"
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
             ],
-            "version": "==7.1.1"
-        },
-        "entrypoints": {
-            "hashes": [
-                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
-                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
-            ],
-            "version": "==0.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
         },
         "flake8": {
             "hashes": [
-                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
-                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
+                "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db",
+                "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"
             ],
             "index": "pypi",
-            "version": "==3.7.9"
+            "version": "==5.0.4"
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "version": "==2.9"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.4"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
+                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
             ],
-            "index": "pypi",
             "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
+            "version": "==4.12.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
         },
         "mccabe": {
             "hashes": [
-                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
             ],
-            "version": "==0.6.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
         },
-        "more-itertools": {
+        "mypy-extensions": {
             "hashes": [
-                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
-                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
             ],
-            "version": "==8.2.0"
+            "version": "==0.4.3"
         },
         "packaging": {
             "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "version": "==20.3"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
         },
         "pathspec": {
             "hashes": [
-                "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
-                "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"
+                "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93",
+                "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"
             ],
-            "version": "==0.8.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.10.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
+                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.2"
         },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "version": "==0.13.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
         },
         "py": {
             "hashes": [
-                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
-                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "version": "==1.8.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
+                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
             ],
-            "version": "==2.5.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.9.1"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
-                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+                "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2",
+                "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"
             ],
-            "version": "==2.1.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
-                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
-            "version": "==3.0.0a1"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
+                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==7.1.3"
         },
         "pytz": {
             "hashes": [
-                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
-                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+                "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
+                "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
             ],
             "index": "pypi",
-            "version": "==2019.3"
-        },
-        "regex": {
-            "hashes": [
-                "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b",
-                "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8",
-                "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3",
-                "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e",
-                "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683",
-                "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1",
-                "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142",
-                "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3",
-                "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468",
-                "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e",
-                "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3",
-                "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a",
-                "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f",
-                "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6",
-                "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156",
-                "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b",
-                "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db",
-                "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd",
-                "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a",
-                "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948",
-                "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
-            ],
-            "version": "==2020.4.4"
+            "version": "==2022.2.1"
         },
         "requests": {
             "hashes": [
-                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
             "index": "pypi",
-            "version": "==2.23.0"
+            "version": "==2.28.1"
         },
-        "six": {
+        "tomli": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "version": "==1.14.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
         },
-        "toml": {
+        "typing-extensions": {
             "hashes": [
-                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
-                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+                "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
+                "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
             ],
-            "version": "==0.10.0"
-        },
-        "typed-ast": {
-            "hashes": [
-                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
-                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
-                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
-                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
-                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
-                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
-                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
-                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
-                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
-                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
-                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
-                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
-                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
-                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
-                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
-                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
-                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
-                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
-                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
-                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
-                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
-            ],
-            "version": "==1.4.1"
+            "markers": "python_version < '3.10'",
+            "version": "==4.3.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "version": "==1.25.9"
-        },
-        "wcwidth": {
-            "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
-            ],
-            "version": "==0.1.9"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.12"
         }
     }
 }

--- a/README.rst
+++ b/README.rst
@@ -213,6 +213,16 @@ commits to the repo. To run these tests yourself: ::
 Changelog
 ---------
 
+3.0.1
+~~~~~
+
+* Relax constraint on jellyfish dependency
+* Add the Midway Islands as a territory
+* Add the 2020 TIGER URLs to shapefile_urls() where possible
+* Sync all states with the latest timezone information
+* Fix bug with lookup() caching logic
+
+
 3.0.0
 ~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license="BSD",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["jellyfish==0.7.2"],
+    install_requires=["jellyfish<1.0"],
     entry_points={"console_scripts": ["states = us.cli.states:main"]},
     platforms=["any"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/us/states.py
+++ b/us/states.py
@@ -88,7 +88,12 @@ DEFAULT_ADDITIONAL_METAPHONES = {
 }
 
 
-def lookup(val, field: Optional[str] = None, use_cache: bool = True, additional_metaphones: Dict[str, str] = DEFAULT_ADDITIONAL_METAPHONES) -> Optional[State]:
+def lookup(
+    val,
+    field: Optional[str] = None,
+    use_cache: bool = True,
+    additional_metaphones: Dict[str, str] = DEFAULT_ADDITIONAL_METAPHONES,
+) -> Optional[State]:
     """Semi-fuzzy state lookup. This method will make a best effort
     attempt at finding the state based on the lookup value provided.
 

--- a/us/states.py
+++ b/us/states.py
@@ -1320,7 +1320,7 @@ WY = State(
 
 
 OBSOLETE: List[State] = [DK, OL, PI]
-TERRITORIES: List[State] = [AS, GU, UM, MP, PR, VI]
+TERRITORIES: List[State] = [AS, GU, MP, PR, VI]
 STATES: List[State] = [
     AL,
     AK,

--- a/us/states.py
+++ b/us/states.py
@@ -51,8 +51,8 @@ class State:
         if not fips:
             return None
 
-        base = f"https://www2.census.gov/geo/tiger/TIGER2020/"
-        base_2010 = f"https://www2.census.gov/geo/tiger/TIGER2010/"
+        base = "https://www2.census.gov/geo/tiger/TIGER2020/"
+        base_2010 = "https://www2.census.gov/geo/tiger/TIGER2010/"
         urls = {
             "tract": urljoin(base, f"TRACT/2020/tl_2020_{fips}_tract.zip"),
             "block": urljoin(base, f"TABBLOCK/2020/tl_2020_{fips}_tabblock10.zip"),

--- a/us/states.py
+++ b/us/states.py
@@ -71,7 +71,18 @@ class State:
         return urls
 
 
-def lookup(val, field: Optional[str] = None, use_cache: bool = True) -> Optional[State]:
+DEFAULT_ADDITIONAL_METAPHONES = {
+    "N HMXR": "N HMPXR",  # New Hamshire -> New Hampshire
+    "WXNKTN TK": "TSTRKT OF KLMB",  # Washington, D.C. -> District of Columbia
+    "WXNKTN STT": "WXNKTN",  # Washington State -> Washington
+    "KMNWL0 OF KNTK": "KNTK",  # Commonwealth of Kentucky -> Kentucky
+    "KMNWL0 OF MSXSTS": "MSXSTS",  # Commonwealth of Massachusetts -> Massachusetts
+    "KMNWL0 OF PNSLFN": "PNSLFN",  # Commonwealth of Pennsylvania -> Pennsylvania
+    "KMNWL0 OF FRJN": "FRJN",  # Commonwealth of Virginia -> Virginia
+}
+
+
+def lookup(val, field: Optional[str] = None, use_cache: bool = True, additional_metaphones: Dict[str, str] = DEFAULT_ADDITIONAL_METAPHONES) -> Optional[State]:
     """Semi-fuzzy state lookup. This method will make a best effort
     attempt at finding the state based on the lookup value provided.
 
@@ -88,6 +99,10 @@ def lookup(val, field: Optional[str] = None, use_cache: bool = True) -> Optional
 
     This method caches non-None results, but can the cache can be bypassed
     with the `use_cache=False` argument.
+
+    You can pass extra metaphones via the `additional_metaphones` argument.
+    Use this to catch typos or alternate names for states that defeat the
+    metaphone algorithm. A default set of alternatives is provided.
     """
 
     matched_state = None
@@ -101,6 +116,8 @@ def lookup(val, field: Optional[str] = None, use_cache: bool = True) -> Optional
         else:
             val = jellyfish.metaphone(val)
             field = "name_metaphone"
+
+            val = additional_metaphones.get(val, val)
 
     # see if result is in cache
     cache_key = f"{field}:{val}"

--- a/us/states.py
+++ b/us/states.py
@@ -106,6 +106,7 @@ def lookup(val, field: Optional[str] = None, use_cache: bool = True) -> Optional
     cache_key = f"{field}:{val}"
     if use_cache and cache_key in _lookup_cache:
         matched_state = _lookup_cache[cache_key]
+        return matched_state
 
     for state in STATES_AND_TERRITORIES:
         if val == getattr(state, field):

--- a/us/states.py
+++ b/us/states.py
@@ -618,6 +618,26 @@ MA = State(
 )
 
 
+UM = State(
+    **{
+        "fips": "74",
+        "name": "Midway Islands",
+        "abbr": "UM",
+        "is_territory": True,
+        "is_obsolete": False,
+        "is_contiguous": False,
+        "is_continental": False,
+        "statehood_year": None,
+        "capital": None,
+        "capital_tz": "Pacific/Pago_Pago",
+        "ap_abbr": None,
+        "time_zones": ["Pacific/Pago_Pago"],
+        "name_metaphone": "MTW ISLNTS",
+
+    }
+)
+
+
 MI = State(
     **{
         "fips": "26",
@@ -1271,7 +1291,7 @@ WY = State(
 
 
 OBSOLETE: List[State] = [DK, OL, PI]
-TERRITORIES: List[State] = [AS, GU, MP, PR, VI]
+TERRITORIES: List[State] = [AS, GU, UM, MP, PR, VI]
 STATES: List[State] = [
     AL,
     AK,

--- a/us/states.py
+++ b/us/states.py
@@ -157,7 +157,15 @@ AK = State(
         "capital": "Juneau",
         "capital_tz": "America/Anchorage",
         "ap_abbr": "Alaska",
-        "time_zones": ["America/Anchorage", "America/Adak"],
+        "time_zones": [
+            "America/Anchorage",
+            "America/Adak",
+            "America/Juneau",
+            "America/Sitka",
+            "America/Metlakatla",
+            "America/Yakutat",
+            "America/Nome",
+        ],
         "name_metaphone": "ALSK",
     }
 )
@@ -423,7 +431,7 @@ ID = State(
         "capital": "Boise",
         "capital_tz": "America/Denver",
         "ap_abbr": "Idaho",
-        "time_zones": ["America/Denver", "America/Los_Angeles"],
+        "time_zones": ["America/Denver", "America/Los_Angeles", "America/Boise"],
         "name_metaphone": "ITH",
     }
 )
@@ -633,7 +641,6 @@ UM = State(
         "ap_abbr": None,
         "time_zones": ["Pacific/Pago_Pago"],
         "name_metaphone": "MTW ISLNTS",
-
     }
 )
 
@@ -651,7 +658,12 @@ MI = State(
         "capital": "Lansing",
         "capital_tz": "America/New_York",
         "ap_abbr": "Mich.",
-        "time_zones": ["America/New_York", "America/Chicago"],
+        "time_zones": [
+            "America/New_York",
+            "America/Chicago",
+            "America/Detroit",
+            "America/Menominee",
+        ],
         "name_metaphone": "MXKN",
     }
 )

--- a/us/states.py
+++ b/us/states.py
@@ -79,6 +79,12 @@ DEFAULT_ADDITIONAL_METAPHONES = {
     "KMNWL0 OF MSXSTS": "MSXSTS",  # Commonwealth of Massachusetts -> Massachusetts
     "KMNWL0 OF PNSLFN": "PNSLFN",  # Commonwealth of Pennsylvania -> Pennsylvania
     "KMNWL0 OF FRJN": "FRJN",  # Commonwealth of Virginia -> Virginia
+    "KMNWL0 OF 0 NR0RN MRN ISLNTS": "NR0RN MRN ISLNTS",  # Commonwealth of the Northern Mariana Islands -> Northern Mariana Islands
+    "MRN ISLNTS": "NR0RN MRN ISLNTS",  # Mariana Islands -> Northern Mariana Islands
+    "MRN ISLNT": "NR0RN MRN ISLNTS",  # Mariana Island -> Northern Mariana Islands
+    "KMNWL0 OF PRT RK": "PRT RK",  # Commonwealth of Puerto Rico -> Puerto Rico
+    "UNTT STTS FRJN ISLNTS": "FRJN ISLNTS",  # United States Virgin Islands -> Virgin Islands
+    "FRJN ISLNTS OF 0 UNTT STTS": "FRJN ISLNTS",  # Virgin Islands of the United States -> Virgin Islands
 }
 
 

--- a/us/states.py
+++ b/us/states.py
@@ -42,8 +42,8 @@ class State:
         return self.name
 
     def shapefile_urls(self) -> Optional[Dict[str, str]]:
-        """ Shapefiles are available directly from the US Census Bureau:
-            https://www.census.gov/cgi-bin/geo/shapefiles/index.php
+        """Shapefiles are available directly from the US Census Bureau:
+        https://www.census.gov/cgi-bin/geo/shapefiles/index.php
         """
 
         fips = self.fips
@@ -66,22 +66,22 @@ class State:
 
 
 def lookup(val, field: Optional[str] = None, use_cache: bool = True) -> Optional[State]:
-    """ Semi-fuzzy state lookup. This method will make a best effort
-        attempt at finding the state based on the lookup value provided.
+    """Semi-fuzzy state lookup. This method will make a best effort
+    attempt at finding the state based on the lookup value provided.
 
-          * two digits will search for FIPS code
-          * two letters will search for state abbreviation
-          * anything else will try to match the metaphone of state names
+      * two digits will search for FIPS code
+      * two letters will search for state abbreviation
+      * anything else will try to match the metaphone of state names
 
-        Metaphone is used to allow for incorrect, but phonetically accurate,
-        spelling of state names.
+    Metaphone is used to allow for incorrect, but phonetically accurate,
+    spelling of state names.
 
-        Exact matches can be done on any attribute on State objects by passing
-        the `field` argument. This skips the fuzzy-ish matching and does an
-        exact, case-sensitive comparison against the specified field.
+    Exact matches can be done on any attribute on State objects by passing
+    the `field` argument. This skips the fuzzy-ish matching and does an
+    exact, case-sensitive comparison against the specified field.
 
-        This method caches non-None results, but can the cache can be bypassed
-        with the `use_cache=False` argument.
+    This method caches non-None results, but can the cache can be bypassed
+    with the `use_cache=False` argument.
     """
 
     matched_state = None

--- a/us/tests/conftest.py
+++ b/us/tests/conftest.py
@@ -1,0 +1,8 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--timezone",
+        action="store_true",
+        dest="timezone",
+        default=False,
+        help="enable checking timezone data against IANA database",
+    )

--- a/us/tests/conftest.py
+++ b/us/tests/conftest.py
@@ -6,3 +6,10 @@ def pytest_addoption(parser):
         default=False,
         help="enable checking timezone data against IANA database",
     )
+    parser.addoption(
+        "--dc-statehood",
+        action="store_true",
+        dest="dc_statehood",
+        default=False,
+        help="enable DC statehood tests (you must export DC_STATEHOOD envvar)",
+    )

--- a/us/tests/test_timezones.py
+++ b/us/tests/test_timezones.py
@@ -1,0 +1,57 @@
+import io
+import gzip
+import tarfile
+
+import pytest
+
+
+STATES_SHAPEFILE = (
+    "https://www2.census.gov/geo/tiger/TIGER2020/STATE/tl_2020_us_state.zip"
+)
+IANA_TIMEZONES = "https://data.iana.org/time-zones/releases/tzdata2022c.tar.gz"
+
+
+def timezones():
+    import iso6709
+    import requests
+
+    timezone_gz = io.BytesIO()
+    for chunk in requests.get(IANA_TIMEZONES).iter_content():
+        timezone_gz.write(chunk)
+    timezone_gz.seek(0)
+
+    gz_fd = gzip.open(timezone_gz)
+    tar_fd = tarfile.open(fileobj=gz_fd, format=tarfile.GNU_FORMAT)
+
+    for line in tar_fd.extractfile("zone.tab"):
+        if not line.startswith(b"US"):
+            continue
+        _, coords, tz_name, _ = line.split(b"\t")
+        coords = iso6709.Location(coords.decode("ASCII"))
+        tz_name = tz_name.decode("ASCII")
+
+        yield (tz_name, coords.lat.decimal, coords.lng.decimal)
+
+
+@pytest.mark.skipif("not config.getoption('timezone')")
+def test_timezone():
+    import us.states
+
+    import geopandas as gpd
+
+    state_df = gpd.read_file(STATES_SHAPEFILE)
+
+    timezone_df = gpd.GeoDataFrame().from_records(
+        timezones(), columns=["timezone", "lat", "lng"], coerce_float=True
+    )
+    timezone_df.geometry = gpd.points_from_xy(timezone_df.lng, timezone_df.lat)
+    timezone_df: gpd.GeoDataFrame = timezone_df.drop(columns=["lat", "lng"])
+    timezone_df = timezone_df.set_crs(crs="EPSG:4326")  # probably?
+    timezone_df = timezone_df.to_crs(state_df.crs)
+
+    joined_df = gpd.sjoin(timezone_df, state_df, how="inner", op="within")
+
+    for row in joined_df[["timezone", "STATEFP"]].itertuples(index=False, name=None):
+        timezone_name, state_fips = row
+        state_obj = us.states.lookup(state_fips, field="fips")
+        assert timezone_name in state_obj.time_zones

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -76,7 +76,10 @@ def test_obsolete_lookup():
 def test_additional_metaphones():
     assert us.states.lookup("New Hamshire") == us.states.NH
 
-    assert us.states.lookup("Nebraska", additional_metaphones={"WNTRWL": "NBRSK"}) == us.states.NE
+    assert (
+        us.states.lookup("Nebraska", additional_metaphones={"WNTRWL": "NBRSK"})
+        == us.states.NE
+    )
 
 
 # test metaphone

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -184,7 +184,7 @@ def test_states_dc():
 
 
 def test_territories():
-    assert len(us.TERRITORIES) == 6
+    assert len(us.TERRITORIES) == 5
 
 
 @pytest.mark.skipif("config.getoption('dc_statehood')")

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -73,6 +73,12 @@ def test_obsolete_lookup():
         assert us.states.lookup(state.name) is None
 
 
+def test_additional_metaphones():
+    assert us.states.lookup("New Hamshire") == us.states.NH
+
+    assert us.states.lookup("Nebraska", additional_metaphones={"WNTRWL": "NBRSK"}) == us.states.NE
+
+
 # test metaphone
 
 

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -117,8 +117,13 @@ def test_wayoming():
     assert us.states.lookup("Wayoming") is None
 
 
-def test_dc():
+@pytest.mark.skipif("config.getoption('dc_statehood')")
+def test_dc_nostate():
     assert us.states.DC not in us.STATES
+
+
+@pytest.mark.skipif("not config.getoption('dc_statehood')")
+def test_dc_state():
     assert us.states.lookup("DC") == us.states.DC
     assert us.states.lookup("District of Columbia") == us.states.DC
     assert "DC" in us.states.mapping("abbr", "name")
@@ -159,19 +164,38 @@ def test_obsolete():
     assert len(us.OBSOLETE) == 3
 
 
+@pytest.mark.skipif("config.getoption('dc_statehood')")
 def test_states():
     assert len(us.STATES) == 50
+
+
+@pytest.mark.skipif("not config.getoption('dc_statehood')")
+def test_states_dc():
+    assert len(us.STATES) == 51
 
 
 def test_territories():
     assert len(us.TERRITORIES) == 6
 
 
+@pytest.mark.skipif("config.getoption('dc_statehood')")
 def test_contiguous():
     # Lower 48
     assert len(us.STATES_CONTIGUOUS) == 48
 
 
+@pytest.mark.skipif("not config.getoption('dc_statehood')")
+def test_contiguous_dc():
+    assert len(us.STATES_CONTIGUOUS) == 49
+
+
+@pytest.mark.skipif("config.getoption('dc_statehood')")
 def test_continental():
     # Lower 48 + Alaska
     assert len(us.STATES_CONTINENTAL) == 49
+
+
+@pytest.mark.skipif("not config.getoption('dc_statehood')")
+def test_continental_dc():
+    assert len(us.STATES_CONTINENTAL) == 50
+

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -124,6 +124,21 @@ def test_dc():
     assert "DC" in us.states.mapping("abbr", "name")
 
 
+def test_cache():
+    key = "abbr:NC"
+    sentinel = object()
+
+    us.states._lookup_cache.clear()
+    assert us.states.lookup("NC") == us.states.NC
+    assert key in us.states._lookup_cache
+
+    # We can't mock the cache so manipulate it directly
+    us.states._lookup_cache[key] = sentinel
+    assert us.states.lookup("NC") == sentinel
+
+    us.states._lookup_cache.clear()
+
+
 # shapefiles
 
 

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -164,7 +164,7 @@ def test_states():
 
 
 def test_territories():
-    assert len(us.TERRITORIES) == 5
+    assert len(us.TERRITORIES) == 6
 
 
 def test_contiguous():

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -175,7 +175,3 @@ def test_contiguous():
 def test_continental():
     # Lower 48 + Alaska
     assert len(us.STATES_CONTINENTAL) == 49
-
-
-def test_dc():
-    assert us.states.DC not in us.STATES

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -198,4 +198,3 @@ def test_continental():
 @pytest.mark.skipif("not config.getoption('dc_statehood')")
 def test_continental_dc():
     assert len(us.STATES_CONTINENTAL) == 50
-

--- a/us/unitedstatesofamerica.py
+++ b/us/unitedstatesofamerica.py
@@ -2,6 +2,7 @@ name = "United States of America"
 abbr = "US"
 
 import datetime
+
 birthday = datetime.date(1776, 7, 4)
 
 __all__ = ["name", "abbr", "birthday"]

--- a/us/unitedstatesofamerica.py
+++ b/us/unitedstatesofamerica.py
@@ -1,4 +1,7 @@
 name = "United States of America"
 abbr = "US"
 
-__all__ = ["name", "abbr"]
+import datetime
+birthday = datetime.date(1776, 7, 4)
+
+__all__ = ["name", "abbr", "birthday"]


### PR DESCRIPTION
Here are the fixes I've merged/made to python-us to get it up and working again. I have uploaded this to PyPI as package [`us-aidentified` version 3.0.1](https://pypi.org/project/us-aidentified/). Feel free to merge this or give any feedback on what you'd like to see for an official release.

#66: I merged this in
#64: close, this obsoletes it
#60: close, this fixes it

#65 close, this fixes it
#63 close, this obsoletes it
#58 close, this fixes it
#57 close, fixed in latest jellyfish
#56 close, this fixes it
#55 close, this fixes it
#54 I wrote a fix to this - turns out the cache wasn't running at all!
#52 I wrote a fix to this. Added a kwarg `additional_metaphones` to lookup() that takes a dict mapping metaphones to metaphones. I added a default dictionary with the Washington DC case, typos we've seen, and the Commonwealths. I think it's an OK fix but your input is welcome.
#33 I think the shapefile URLs take care of this?
#32 the DC_STATEHOOD envvar takes care of this, close
#14 and #15: close, this fixes it. I wrote a test that uses census shapefiles + the IANA timezone database to validate we have up-to-date timezones in each state.