### PR TITLE
Prepare for 4.0.0 release

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Before spending time working on a pull request, please [open an idea discussion]
 To speed up the review process, please ensure:
 
 * your change has corresponding tests that run with the existing pytest suite and pass.
-* the code is formatted with [black](https://black.readthedocs.io/en/stable/index.html), included in the dev dependencies.
+* the code is formatted with [ruff](https://docs.astral.sh/ruff/), included in the dev dependencies.
 * you are open to feedback!
 
 Thank you and we look forward to your contribution! ✨

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Set version from tag
         run: uv version "${GITHUB_REF#refs/tags/v}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
 
       - name: Set version from tag
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          sed -i "s/^__version__ = .*/__version__ = \"${VERSION}\"/" us/version.py
+        run: uv version "${GITHUB_REF#refs/tags/v}"
 
       - name: Build package
         run: uv build

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: "3.14"
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: "3.14"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: "3.14"
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: "3.14"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 4.0.0
 
 * add counties, thanks to [Ray Kiddy](https://github.com/rkiddy)
-* DC has returned to `STATES_AND_TERRITORIES`, thanks to [Kavi Gupta](https://github.com/kavigupta)
 * add `clean_name()` method and `fallback_func` parameter to `lookup()` to provide customizable matching, thanks to [Max Filenko](https://github.com/mfilenko) and [Charlie Tonneslan](https://github.com/c-tonneslan)
+* DC has returned to `STATES_AND_TERRITORIES`, thanks to [Kavi Gupta](https://github.com/kavigupta)
+* add `us.__version__` and deprecate `us.version`
 * fix `py.typed` location, thanks to [johnw-bluemark](https://github.com/johnw-bluemark)
 * add support for Python 3.13 and 3.14
 * switch to [uv](https://docs.astral.sh/uv/) for development and packaging

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ As per usual:
 pip install us
 ```
 
-or 
+or
 
 ```
-uv install us
+uv add us
 ```
 
 
@@ -39,7 +39,8 @@ This project uses [uv](https://docs.astral.sh/uv/) for development.
 ```
 uv sync
 uv run pytest
-uv run black --check us
+uv run ruff check us
+uv run ruff format --check us
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,15 @@
 [build-system]
 requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "us"
+version = "4.0.0.dev0"
 description = "US state meta information and other fun stuff"
 readme = "README.md"
 urls.Homepage = "https://github.com/unitedstates/python-us/"
 urls."Issue tracker" = "https://github.com/unitedstates/python-us/issues"
 requires-python = ">=3.8"
-dynamic = ["version"]
 authors = [{ name = "Jeremy Carbaugh", email = "jeremy@jcarbaugh.com" }]
 classifiers = [
     "Programming Language :: Python",
@@ -29,9 +30,6 @@ states = "us.cli.states:main"
 
 [dependency-groups]
 dev = ['ruff', 'pytest', 'pytz']
-
-[tool.setuptools.dynamic]
-version = { attr = "us.version.__version__" }
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "us"
 version = "4.0.0.dev0"
-description = "US state meta information and other fun stuff"
+description = "US state metadata"
 readme = "README.md"
 urls.Homepage = "https://github.com/unitedstates/python-us/"
 urls."Issue tracker" = "https://github.com/unitedstates/python-us/issues"

--- a/us/__init__.py
+++ b/us/__init__.py
@@ -1,10 +1,40 @@
-from .states import (  # noqa
-    STATES,  # noqa
-    STATES_CONTIGUOUS,  # noqa
-    STATES_CONTINENTAL,  # noqa
-    TERRITORIES,  # noqa
-    STATES_AND_TERRITORIES,  # noqa
-    OBSOLETE,  # noqa
-)  # noqa
-from .unitedstatesofamerica import *  # noqa
-from .version import __version__ as version  # noqa
+from .states import (
+    STATES,
+    STATES_CONTIGUOUS,
+    STATES_CONTINENTAL,
+    TERRITORIES,
+    STATES_AND_TERRITORIES,
+    OBSOLETE,
+)
+from .unitedstatesofamerica import name, abbr, birthday
+
+try:
+    from importlib.metadata import version as _get_version
+
+    __version__ = _get_version("us")
+except Exception:
+    __version__ = "unknown"
+
+
+# Deprecated support for us.version. Remove in the 5.0 release.
+def __getattr__(name):
+    if name == "version":
+        from warnings import warn
+
+        warn("us.version is deprecated, use us.__version__ instead", DeprecationWarning)
+        return __version__
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+__all__ = [
+    "STATES",
+    "STATES_CONTIGUOUS",
+    "STATES_CONTINENTAL",
+    "TERRITORIES",
+    "STATES_AND_TERRITORIES",
+    "OBSOLETE",
+    "name",
+    "abbr",
+    "birthday",
+    "__version__",
+]

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -16,6 +16,12 @@ def test_attribute():
         assert state == getattr(us.states, state.abbr)
 
 
+def test_version_deprecation():
+    with pytest.warns(DeprecationWarning):
+        version = us.version
+    assert version == us.__version__
+
+
 def test_valid_timezones():
     for state in us.STATES_AND_TERRITORIES:
         if state.capital:

--- a/us/version.py
+++ b/us/version.py
@@ -1,1 +1,6 @@
-__version__ = "4.0.0.dev"
+try:
+    from importlib.metadata import version
+
+    __version__ = version("us")
+except Exception:
+    __version__ = "unknown"

--- a/us/version.py
+++ b/us/version.py
@@ -1,6 +1,0 @@
-try:
-    from importlib.metadata import version
-
-    __version__ = version("us")
-except Exception:
-    __version__ = "unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -468,6 +468,7 @@ wheels = [
 
 [[package]]
 name = "us"
+version = "4.0.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "jellyfish", version = "1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
## Summary

This PR modernizes the project's packaging, tooling, and CI configuration in preparation for the 4.0.0 release — the first new release in several years.

The project was already in good shape (uv, ruff, GitHub Actions, OIDC publishing to PyPI) so this is a targeted cleanup pass rather than a full overhaul.

### Changes

**Packaging (`pyproject.toml`)**
- Added missing `build-backend = "setuptools.build_meta"` to `[build-system]` (required by PEP 517)
- Moved from `dynamic = ["version"]` (setuptools attribute lookup) to a static `version = "4.0.0.dev0"` — cleaner and compatible with `uv version` for release automation

**Version module (`us/version.py`)**
- Replaced hardcoded `__version__` string with `importlib.metadata.version("us")` so the reported version always matches the installed package
- Added a `try/except` fallback to `"unknown"` for environments where the package metadata isn't available

**Release workflow (`.github/workflows/publish.yml`)**
- Replaced the fragile `sed` regex that patched `version.py` at release time with `uv version "${GITHUB_REF#refs/tags/v}"`, which sets the version directly in `pyproject.toml`
- To release: push a tag `v4.0.0` → CI runs tests → `uv version` sets the version → `uv build` → publishes to PyPI via Trusted Publishing (no API token needed)

**Documentation**
- `README.md`: fixed `uv install us` (not a valid command) → `uv add us`; replaced `uv run black --check us` with the correct `ruff` commands
- `CONTRIBUTING.md`: updated formatting tool reference from `black` to `ruff`