### PR TITLE
Add us.states.enumeration() returning a dynamic Enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * add counties, thanks to [Ray Kiddy](https://github.com/rkiddy)
 * add `clean_name()` method and `fallback_func` parameter to `lookup()` to provide customizable matching, thanks to [Max Filenko](https://github.com/mfilenko) and [Charlie Tonneslan](https://github.com/c-tonneslan)
 * DC has returned to `STATES_AND_TERRITORIES`, thanks to [Kavi Gupta](https://github.com/kavigupta)
+* add `us.states.enumeration()` for dynamic `Enum` construction from `State` attributes
 * add `us.__version__` and deprecate `us.version`
 * fix `py.typed` location, thanks to [johnw-bluemark](https://github.com/johnw-bluemark)
 * add support for Python 3.13 and 3.14

--- a/README.md
+++ b/README.md
@@ -234,6 +234,34 @@ additional states argument:
 ```
 
 
+### Enumerations
+
+The `enumeration()` method dynamically constructs an `Enum` of states, keyed
+by state abbreviation. The value of each member is taken from the attribute
+named by `value_field`, which defaults to `name`.
+
+```python
+>>> States = us.states.enumeration()
+>>> States.VA
+<States.VA: 'Virginia'>
+>>> States.VA.value
+'Virginia'
+
+>>> States = us.states.enumeration('fips')
+>>> States.CA.value
+'06'
+```
+
+Like `mapping()`, this method uses `us.STATES_AND_TERRITORIES` as the
+default state list, which can be overridden by passing a `states` argument:
+
+```python
+>>> States = us.states.enumeration('fips', states=[us.states.DC, us.states.MD])
+>>> list(States)
+[<States.DC: '11'>, <States.MD: '24'>]
+```
+
+
 ### DC should be granted statehood
 
 Washington, DC does not appear in `us.STATES` or any of the

--- a/us/states.py
+++ b/us/states.py
@@ -1,6 +1,7 @@
 import os
 import re
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from enum import Enum
+from typing import Any, Callable, Dict, Iterable, List, Optional, Type
 from urllib.parse import urljoin
 
 import jellyfish  # type: ignore
@@ -201,6 +202,12 @@ def mapping(from_field: str, to_field: str, states: Optional[Iterable[State]] = 
     if states is None:
         states = STATES_AND_TERRITORIES
     return {getattr(s, from_field): getattr(s, to_field) for s in states}
+
+
+def enumeration(value_field: str = "name", states: Optional[Iterable[State]] = None) -> Type[Enum]:
+    if states is None:
+        states = STATES_AND_TERRITORIES
+    return Enum("States", {s.abbr: getattr(s, value_field) for s in states})
 
 
 AL = State(

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -201,6 +201,34 @@ def test_custom_mapping():
     assert "MD" in mapping
 
 
+# enumerations
+
+
+def test_enumeration():
+    states = us.STATES[:5]
+    enum = us.states.enumeration("name", states=states)
+    for state in states:
+        assert enum[state.abbr].value == state.name
+
+
+def test_enumeration_default_states():
+    enum = us.states.enumeration("name")
+    assert enum["VA"].value == "Virginia"
+    assert enum["DC"].value == "District of Columbia"
+
+
+def test_enumeration_default_value_field():
+    enum = us.states.enumeration()
+    assert enum["VA"].value == "Virginia"
+
+
+def test_custom_enumeration():
+    enum = us.states.enumeration("fips", states=[us.states.DC, us.states.MD])
+    assert len(enum) == 2
+    assert enum["DC"].value == us.states.DC.fips
+    assert enum["MD"].value == us.states.MD.fips
+
+
 # known bugs
 
 


### PR DESCRIPTION
## Summary

Adds a new `us.states.enumeration()` helper that dynamically constructs an `Enum` of states keyed by state abbreviation. It mirrors the call shape of `us.states.mapping()`: an optional `states` iterable selects which `State` objects to include (defaulting to `STATES_AND_TERRITORIES`), and a `value_field` argument picks which `State` attribute supplies each member's value.

The enum member **name** is always the state's `abbr` — `abbr` is guaranteed to be a valid Python identifier, so users can't accidentally produce invalid member names by picking a `value_field` like `"name"` (`"New York"`) or `"fips"` (`"01"`).

Closes #28 

## Example

```python
>>> States = us.states.enumeration()
>>> States.VA
<States.VA: 'Virginia'>

>>> States = us.states.enumeration("fips")
>>> States.CA.value
'06'

>>> States = us.states.enumeration("fips", states=[us.states.DC, us.states.MD])
>>> list(States)
[<States.DC: '11'>, <States.MD: '24'>]
```

## Approach

`enumeration()` lives next to `mapping()` in `us/states.py` and delegates to the stdlib functional API: `Enum("States", {s.abbr: getattr(s, value_field) for s in states})`. No changes to `mapping()` or to `State`.

## Test plan

- [x] `uv run pytest us/tests/test_us.py` passes
- [x] Default `value_field` (`"name"`) returns expected member values
- [x] Explicit `states=` iterable produces an enum of exactly that subset
- [x] Non-name `value_field` (`"fips"`) values pass through unchanged