### PR TITLE
Fix crash in states CLI when printing counties

### DIFF
--- a/us/cli/states.py
+++ b/us/cli/states.py
@@ -31,7 +31,11 @@ def main():
         for key in sorted(data.keys()):
             val = data[key]
 
-            if isinstance(val, (list, tuple)):
+            if key == "counties":
+                # counties is a list of County objects, not strings, so it
+                # can't be joined like the other list attributes
+                val = "%d counties" % len(val)
+            elif isinstance(val, (list, tuple)):
                 val = ", ".join(val)
 
             sys.stdout.write("    %s: %s\n" % (key, val))

--- a/us/tests/test_us.py
+++ b/us/tests/test_us.py
@@ -6,6 +6,7 @@ import pytest
 import pytz
 
 import us
+from us.cli import states as states_cli
 from us.states import County
 
 # attribute
@@ -244,6 +245,19 @@ def test_wayoming():
 
 def test_dc():
     assert us.states.DC not in us.STATES
+
+
+# cli
+
+
+def test_cli_lookup(capsys, monkeypatch):
+    # the counties attribute is a list of County objects, which used to crash
+    # the "other attributes" loop when it tried to join them as strings
+    monkeypatch.setattr("sys.argv", ["states", "MD"])
+    states_cli.main()
+    out = capsys.readouterr().out
+    assert "Maryland" in out
+    assert "counties" in out
 
 
 # shapefiles


### PR DESCRIPTION
The \`counties\` attribute added in 4.0.0 is a list of \`County\` objects, but the CLI's "other attributes" loop still tries to \`", ".join()\` any list value. Joining the County objects raises \`TypeError: sequence item 0: expected str instance, County found\`, so running \`states <state>\` crashes for every state (it dies right after printing the scalar attributes).

This special-cases counties to print a count instead, which avoids dumping hundreds of county names inline and keeps the existing join path for the string-valued lists like \`time_zones\`. I added a small regression test that runs the CLI and checks it completes; it fails on main and passes with the change. Thanks for the recent 4.0.0 work on this library.